### PR TITLE
SRE-2386: use latest ARC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: utility-staging-amd64
     steps:
     - name: checkout
       uses: actions/checkout@v1


### PR DESCRIPTION
## Linear Ticket

SRE-2386

## Overview
-  use latest ARC

## Areas to focus on
- use  utility-staging-amd64

## Summary by Sourcery

CI:
- Change the CI workflow to run on 'utility-staging-amd64' instead of 'ubuntu-latest'.